### PR TITLE
fix link for "Continuous Infrastructure with Ansible, Molecule & Trav…

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Example projects showing how to do test-driven development of Ansible roles and 
 This project build on top of [molecule-ansible-docker-vagrant](https://github.com/jonashackt/molecule-ansible-docker-vagrant), where all the basics on how to do test-driven development of Ansible roles with Molecule is described. Have a look into the blog series so far:
 
 * [Test-driven infrastructure development with Ansible & Molecule](https://blog.codecentric.de/en/2018/12/test-driven-infrastructure-ansible-molecule/)
-* [Continuous Infrastructure with Ansible, Molecule & TravisCI](https://blog.codecentric.de/en/2018/12/test-driven-infrastructure-ansible-molecule/)
+* [Continuous Infrastructure with Ansible, Molecule & TravisCI](https://blog.codecentric.de/en/2018/12/continuous-infrastructure-ansible-molecule-travisci/)
 * [Continuous cloud infrastructure with Ansible, Molecule & TravisCI on AWS](https://blog.codecentric.de/en/2019/01/ansible-molecule-travisci-aws/)
 
 ## What about Multicloud?


### PR DESCRIPTION
…isCI"

"Continuous Infrastructure with Ansible, Molecule & TravisCI" blog post link is the same as for "Test-driven infrastructure development with Ansible & Molecule"